### PR TITLE
Update ivy-clipmenu.el

### DIFF
--- a/ivy-clipmenu.el
+++ b/ivy-clipmenu.el
@@ -73,7 +73,8 @@
   :group 'ivy)
 
 (defcustom ivy-clipmenu-directory
-  (or (getenv "XDG_RUNTIME_DIR")
+  (or (getenv "CM_DIR")
+      (getenv "XDG_RUNTIME_DIR")
       (getenv "TMPDIR")
       (temporary-file-directory))
   "Base directory for clipmenu's data."


### PR DESCRIPTION
allows you to use the value set by the user in CM_DIR to handle the clipmenu cache