### PR TITLE
Updated ivy-clipmenu.el to require and support Clipmenu version 6

### DIFF
--- a/ivy-clipmenu.el
+++ b/ivy-clipmenu.el
@@ -80,7 +80,7 @@
   :type 'string
   :group 'ivy-clipmenu)
 
-(defconst ivy-clipmenu-executable-version 5
+(defconst ivy-clipmenu-executable-version 6
    "The major version number for the clipmenu executable.")
 
 (defconst ivy-clipmenu-cache-directory
@@ -91,7 +91,7 @@
   "Directory where the clips are stored.")
 
 (defconst ivy-clipmenu-cache-file-pattern
-  (f-join ivy-clipmenu-cache-directory "line_cache_*")
+  (f-join ivy-clipmenu-cache-directory "line_cache*")
   "Glob pattern matching the locations on disk for clipmenu's labels.")
 
 (defcustom ivy-clipmenu-history-length


### PR DESCRIPTION
Most package managers now ship version 6.0 or later, so it is better to have that version as the default. You could also support both with just a few more lines of code (not in my commit).